### PR TITLE
Make model training reproducible

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -544,7 +544,8 @@ class ActiveMatching(Matching) :
     def __init__(self, 
                  variable_definition, 
                  data_sample = None,
-                 num_cores = None) :
+                 num_cores = None,
+                 random_seed = None) :
         """
         Initialize from a data model and data sample.
 
@@ -606,6 +607,8 @@ class ActiveMatching(Matching) :
             self.num_cores = multiprocessing.cpu_count()
         else :
             self.num_cores = num_cores
+
+        self.random_seed = random_seed
 
         training_dtype = [('label', 'S8'), 
                           ('distances', 'f4', 
@@ -714,7 +717,8 @@ class ActiveMatching(Matching) :
                                            self.learner,
                                            self.data_model, 
                                            self.num_cores,
-                                           k=n_folds)
+                                           k=n_folds,
+                                           random_seed=self.random_seed)
 
         return alpha
 

--- a/dedupe/crossvalidation.py
+++ b/dedupe/crossvalidation.py
@@ -19,7 +19,7 @@ def gridSearch(training_data,
                num_cores,
                k=3,
                search_space=[.00001, .0001, .001, .01, .1, 1],
-               randomize=True):
+               random_seed=None):
 
     if num_cores < 2 :
         from multiprocessing.dummy import Pool
@@ -28,7 +28,8 @@ def gridSearch(training_data,
 
     pool = Pool()
 
-    training_data = training_data[numpy.random.permutation(training_data.size)]
+    prng = numpy.random.RandomState(random_seed)
+    training_data = training_data[prng.permutation(training_data.size)]
 
     logger.info('using cross validation to find optimum alpha...')
     best_score = 0


### PR DESCRIPTION
Reproducible models are useful in production and for debugging. But right now, trained models aren't reproducible given the same training data and data model because cross-validation folds are random. More training data or simpler models might make training more predictable but not deterministic.

```gridSearch``` currently has an unimplemented ```randomize``` parameter. This commit (a) replaces it with ```random_seed``` which defaults to None (current behavior), and (b) adds a random_seed attribute to ```ActiveMatching``` that's passed to ```gridSearch``` on training.