### PR TITLE
Added check for empty dictionary of records in RecordLink.sample

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -988,6 +988,11 @@ class RecordLink(RecordLinkMatching, ActiveMatching) :
         
         sample_size -- Size of the sample to draw
         '''
+        if len(data_1) == 0:
+            raise ValueError('Dictionary of records from first dataset is empty.')
+        elif len(data_2) == 0:
+            raise ValueError('Dictionary of records from second dataset is empty.')
+
         if len(data_1) > len(data_2) :
             data_1, data_2 = data_2, data_1
 

--- a/dedupe/sampling.py
+++ b/dedupe/sampling.py
@@ -107,8 +107,11 @@ def linkSamplePredicates(sample_size, predicates, items1, items2) :
             yield None
             continue
 
-        items1.rotate(random.randrange(n_1))
-        items2.rotate(random.randrange(n_2))
+        try:
+            items1.rotate(random.randrange(n_1))
+            items2.rotate(random.randrange(n_2))
+        except ValueError :
+            raise ValueError("Empty itemset.")
 
         try :
             items1.reverse()


### PR DESCRIPTION
Giving an empty dictionary as argument to 'RecordLink.sample' raises a cryptic 'ValueError' originating from the use of 'random.randrange' function, with zero as an argument, in 'sampling.py' module. This fix inserts a check for empty dictionary arguments in 'RecordLink.sample' function, and raises an appropriate exception message accordingly.