### PR TITLE
Cleanup process pool after initializing ActiveLearning

### DIFF
--- a/dedupe/training.py
+++ b/dedupe/training.py
@@ -53,6 +53,8 @@ class ActiveLearning(object) :
             pool.map(fieldDistance, 
                      chunker(candidates, 100),
                      2))
+        
+        pool.terminate()
 
         self.seen_indices = set()
 


### PR DESCRIPTION
On machines with many processing cores, it's apparently necessary to terminate the process pool after using it in this case since all of the processes that this ``__init__`` method uses are still hanging around even if you delete the parent object. 