### PR TITLE
Updated os-x install doc

### DIFF
--- a/docs/OSX-Install-Notes.rst
+++ b/docs/OSX-Install-Notes.rst
@@ -38,6 +38,14 @@ Edit site.cfg and uncomment/update the code to match below:
 
 ::
 
+    [DEFAULT]
+    library_dirs = /usr/local/opt/openblas/lib
+    include_dirs = /usr/local/opt/openblas/include
+
+    [atlas]
+    atlas_libs = openblas
+    libraries = openblas
+
     [openblas]
     libraries = openblas
     library_dirs = /usr/local/opt/openblas/lib


### PR DESCRIPTION
This worked for me to get multiprocessing up and running on os-x. I think the main thing was also setting the [atlas] header to point to openblas.