### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Features
 Features
 - Speed up learning
 - Parallelize sampling
-- Optional [CRF Edit Distance](http://dedupe.readthedocs.org/en/latest/Variable-definition.html#optional-edit-distance)
+- Optional [CRF Edit Distance](https://dedupe.readthedocs.io/en/latest/Variable-definition.html#optional-edit-distance)
 
 ## 0.8.0
 Support for Python 3.4 added. Support for Python 2.6 dropped.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ __dedupe__ will help you:
 dedupe takes in human training data and comes up with the best rules for your dataset to quickly and automatically find similar records, even with very large databases.
 
 ## Important links
-* Documentation: http://dedupe.rtfd.org/
+* Documentation: https://dedupe.readthedocs.io/
 * Repository: https://github.com/datamade/dedupe
 * Issues: https://github.com/datamade/dedupe/issues
 * Examples: https://github.com/datamade/dedupe-examples

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -616,7 +616,7 @@ class ActiveMatching(Matching):
         describes a variable to use for comparing records.
 
         For details about variable types, check the documentation.
-        <http://dedupe.readthedocs.org>`_
+        <https://dedupe.readthedocs.io>`_
 
         In the data_sample, each element is a tuple of two
         records. Each record is, in turn, a tuple of the record's key and

--- a/docs/Variable-definition.rst
+++ b/docs/Variable-definition.rst
@@ -237,7 +237,7 @@ Address Type
 ^^^^^^^^^^^^
 
 An 'Address' variable should be used for United States addresses. It
-uses the `usaddress <http://usaddress.readthedocs.org/en/latest/>`__
+uses the `usaddress <https://usaddress.readthedocs.io/en/latest/>`__
 package to split apart an address string into components like address
 number, street name, and street type and compares component to component.
 
@@ -253,7 +253,7 @@ Name Type
 
 A 'Name' variable should be used for a field that contains American
 names, corporations and households. It uses the `probablepeople
-<http://probablepeople.readthedocs.org/en/latest/>`__ package to split
+<https://probablepeople.readthedocs.io/en/latest/>`__ package to split
 apart an name string into components like give name, surname,
 generational suffix, for people names, and abbreviation, company type,
 and legal form for corporations.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ dedupe takes in human training data and comes up with the best rules for your da
 Important links
 ===============
 
-* Documentation: http://dedupe.rtfd.org/
+* Documentation: https://dedupe.readthedocs.io/
 * Repository: https://github.com/datamade/dedupe
 * Issues: https://github.com/datamade/dedupe/issues
 * Examples: https://github.com/datamade/dedupe-examples

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     
     Important links:
     
-    * Documentation: http://dedupe.rtfd.org/
+    * Documentation: https://dedupe.readthedocs.io/
     * Repository: https://github.com/datamade/dedupe
     * Issues: https://github.com/datamade/dedupe/issues
     * Examples: https://github.com/datamade/dedupe-examples


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.