### PR TITLE
load data into defaultdict

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -548,7 +548,7 @@ class StaticMatching(Matching):
             for predicate in full_predicate:
                 if hasattr(predicate, "index") and predicate.index is None:
                     predicate.index = predicate.initIndex()
-                    doc_to_id_max_id = numpy.amax([v for k, v in doc_to_ids[predicate].items()])
+                    doc_to_id_max_id = max(doc_to_ids[predicate].values())
                     predicate.index._doc_to_id = defaultdict(itertools.count(doc_to_id_max_id).next, doc_to_ids[predicate])
                     if hasattr(predicate, "canopy"):
                         predicate.canopy = canopies[predicate]

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -549,7 +549,14 @@ class StaticMatching(Matching):
                 if hasattr(predicate, "index") and predicate.index is None:
                     predicate.index = predicate.initIndex()
                     doc_to_id_max_id = max(doc_to_ids[predicate].values())
-                    predicate.index._doc_to_id = defaultdict(itertools.count(doc_to_id_max_id + 1).next, doc_to_ids[predicate])
+                    try:
+                        predicate.index._doc_to_id = defaultdict(
+                            itertools.count(doc_to_id_max_id + 1).next)
+
+                    except AttributeError:  # py 3
+                        predicate.index._doc_to_id = defaultdict(
+                            itertools.count(doc_to_id_max_id + 1).__next__)
+
                     if hasattr(predicate, "canopy"):
                         predicate.canopy = canopies[predicate]
                     else:

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -548,7 +548,8 @@ class StaticMatching(Matching):
             for predicate in full_predicate:
                 if hasattr(predicate, "index") and predicate.index is None:
                     predicate.index = predicate.initIndex()
-                    predicate.index._doc_to_id = doc_to_ids[predicate]
+                    doc_to_id_max_id = numpy.amax([v for k, v in doc_to_ids[predicate].items()])
+                    predicate.index._doc_to_id = defaultdict(itertools.count(doc_to_id_max_id).next, doc_to_ids[predicate])
                     if hasattr(predicate, "canopy"):
                         predicate.canopy = canopies[predicate]
                     else:

--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -549,7 +549,7 @@ class StaticMatching(Matching):
                 if hasattr(predicate, "index") and predicate.index is None:
                     predicate.index = predicate.initIndex()
                     doc_to_id_max_id = max(doc_to_ids[predicate].values())
-                    predicate.index._doc_to_id = defaultdict(itertools.count(doc_to_id_max_id).next, doc_to_ids[predicate])
+                    predicate.index._doc_to_id = defaultdict(itertools.count(doc_to_id_max_id + 1).next, doc_to_ids[predicate])
                     if hasattr(predicate, "canopy"):
                         predicate.canopy = canopies[predicate]
                     else:


### PR DESCRIPTION
I had an issue if i'am using the StaticGazetteer. When i save the index to a file and load it later, i was not able to index new data. (Get a KeyError). The pickle library loads the do_to_id as python dict instant of a defaultdict. I use the factory from the TfIdfIndex, but i am not 100% sure if this is the right place to this. 