### PR TITLE
fixed memory leak in convenience.trainingDataLink()

### DIFF
--- a/dedupe/convenience.py
+++ b/dedupe/convenience.py
@@ -116,9 +116,16 @@ def trainingDataLink(data_1, data_2, common_key, training_size=50000) : # pragma
         if keys_1 and keys_2 :
             matched_pairs.update(itertools.product(keys_1, keys_2))
 
-    distinct_pairs = set(itertools.product(data_1.keys(), data_2.keys()))
-    distinct_pairs -= matched_pairs
-    distinct_pairs = random.sample(distinct_pairs, training_size)
+    keys_1 = tuple(data_1.keys())
+    keys_2 = tuple(data_2.keys())
+
+    possible_pairs = len(keys_1) * len(keys_1) - len(matched_pairs)
+
+    # guessing random pairs would be hard if only few are possible
+    while len(distinct_pairs) < min(training_size, possible_pairs / 2):
+        pair = (random.choice(keys_1), random.choice(keys_2))
+        if pair not in matched_pairs:
+            distinct_pairs.add(pair)
 
     matched_records = [(data_1[key_1], data_2[key_2])
                        for key_1, key_2 in matched_pairs]


### PR DESCRIPTION
The current implementation `convenience.trainingDataLink()` builds a full cartesian product of the two datasets, which even for moderte datasets (e.g., 10k each) would be 100 million records and gigs of memory, just to sample a couple of thousand of them. This is a simple and memory efficient solution that achieves the same result by picking random elements from `data_1` and `data_2` and using them as a distinct pair unless they are in fact matched. 

If we try to find about as many training pairs as their are pairs in total, this would take a long time to guess, so it's best keep well below that number. One could potentially return just the cartesian product in this case, but it's only relevant for datasets when each of them have about 300 records, so more of an edge case.

IMHO the break condition should really be
```python
while len(distinct_pairs) < min(training_size - len(matched_pairs), possible_pairs / 2):
```
so that the total records match the request training size, but this implementation is backward compatible.

The same could potentially be achieved by `core.randomPairsMatch()`, but this function seems not particularly adapted to this case, where we disallow certain pairs, in this case those that are already matched.