### PR TITLE
Fix consoleLabel example in docs

### DIFF
--- a/docs/API-documentation.rst
+++ b/docs/API-documentation.rst
@@ -263,7 +263,7 @@ Convenience Functions
 
    .. code:: python
 
-      > deduper = Dedupe(variables)
+      > deduper = dedupe.Dedupe(variables)
       > deduper.sample(data)
       > dedupe.consoleLabel(deduper)
 

--- a/docs/API-documentation.rst
+++ b/docs/API-documentation.rst
@@ -263,9 +263,9 @@ Convenience Functions
 
    .. code:: python
 
-      > dedupe = Dedupe(variables)
-      > dedupe.sample(data)
-      > dedupe.consoleLabel(dedupe)
+      > deduper = Dedupe(variables)
+      > deduper.sample(data)
+      > dedupe.consoleLabel(deduper)
 
 .. py:function:: trainingDataLink(data_1, data_2, common_key[, training_size])
 


### PR DESCRIPTION
The current `consoleLabel` example in the docs appears to be broken:

```py
dedupe = Dedupe(variables)
dedupe.sample(data)
dedupe.consoleLabel(dedupe)
```

This code suggests that `consoleLabel` is an instance method of a `Dedupe` object, but in fact it appears to be a function of the `dedupe` module, not an instance method.

This PR fixes the example by renaming the `dedupe` variable to `deduper` so that it doesn't shadow the `dedupe` module.