### PR TITLE
except key error

### DIFF
--- a/dedupe/api.py
+++ b/dedupe/api.py
@@ -532,7 +532,10 @@ class StaticMatching(Matching):
                     if hasattr(predicate, "canopy"):
                         predicate.canopy = canopies[predicate]
                     else:
-                        predicate.index._index = indices[predicate]
+                        try:
+                            predicate.index._index = indices[predicate]
+                        except KeyError:
+                            pass
 
         self.loaded_indices = True
 


### PR DESCRIPTION
e.g. levenshtein indices will not written to file according to line 158
had a problem if i try to load my file with the indices again. Levenshtein has no _index attribute an will not written to the file. 