### PR TITLE
Added 'previous' option to manual labelling (`consoleLabel`)

### DIFF
--- a/dedupe/convenience.py
+++ b/dedupe/convenience.py
@@ -30,7 +30,7 @@ def consoleLabel(deduper): # pragma: no cover
                     in deduper.data_model.primary_fields)
 
 
-    buffer_len = 0 # Max number of previous operations
+    buffer_len = 1 # Max number of previous operations
     record_label_buffer = []
     uncertain_pairs = []
 

--- a/dedupe/convenience.py
+++ b/dedupe/convenience.py
@@ -34,21 +34,20 @@ def consoleLabel(deduper): # pragma: no cover
     uncertain_pairs = []
 
     while not finished :       
-        if len(examples_buffer) and use_previous:
-            record_pair = examples_buffer.pop(0)[0]
+        if examples_buffer and use_previous:
+            record_pair, _ = examples_buffer.pop(0)
+            use_previous = False
         else:
             if not uncertain_pairs:
                 uncertain_pairs = deduper.uncertainPairs()
             record_pair = uncertain_pairs.pop()
-             
-        use_previous = False
-        
+                     
         n_match_in_buffer = sum(label=='match' for _, label in examples_buffer) 
         n_distinct_in_buffer = sum(label=='distinct' for _, label in examples_buffer)
                                                                                         
         n_match, n_distinct = (len(deduper.training_pairs['match']) + n_match_in_buffer,
                         len(deduper.training_pairs['distinct']) + n_distinct_in_buffer)
-      
+        
         label = ''
 
         for pair in record_pair:
@@ -60,44 +59,42 @@ def consoleLabel(deduper): # pragma: no cover
         print("{0}/10 positive, {1}/10 negative".format(n_match, n_distinct),
                 file=sys.stderr)
         print('Do these records refer to the same thing?', file=sys.stderr)
+        
         valid_response = False
         while not valid_response:
-            if len(examples_buffer):
-                print('(y)es / (n)o / (u)nsure / (f)inished / (p)revious', file=sys.stderr)
-                user_input = input()
-                if user_input in ['y', 'n', 'u', 'f', 'p']:
-                    valid_response = True
-            else:
-                print('(y)es / (n)o / (u)nsure / (f)inished', file=sys.stderr)
-                user_input = input()
-                if user_input in ['y', 'n', 'u', 'f']:
-                    valid_response = True
+            if examples_buffer:
+                prompt = '(y)es / (n)o / (u)nsure / (f)inished / (p)revious'
+                valid_responses = {'y', 'n', 'u', 'f', 'p'}
+            else: 
+                prompt = '(y)es / (n)o / (u)nsure / (f)inished'
+                valid_responses = {'y', 'n', 'u', 'f'}
 
-        if user_input == 'y' :
-            examples_buffer.insert(0, (record_pair, 'match'))
-        elif user_input == 'n' :
-            examples_buffer.insert(0, (record_pair, 'distinct'))
-        elif user_input == 'u':
-            examples_buffer.insert(0, (record_pair, 'uncertain'))
-        else:
-            uncertain_pairs.append(record_pair)
-            if user_input == 'f':
-                print('Finished labeling', file=sys.stderr)
-                finished = True
-            elif (user_input == 'p') and len(examples_buffer):
-                use_previous = True
-            else:
-                print('Nonvalid response', file=sys.stderr)
-                raise
+            print(prompt, file=sys.stderr)
+            user_input = input()
+            if user_input in valid_responses:
+                valid_response = True
+
+                if user_input == 'y' :
+                    examples_buffer.insert(0, (record_pair, 'match'))
+                elif user_input == 'n' :
+                    examples_buffer.insert(0, (record_pair, 'distinct'))
+                elif user_input == 'u':
+                    examples_buffer.insert(0, (record_pair, 'uncertain'))
+                elif user_input == 'f':
+                    print('Finished labeling', file=sys.stderr)
+                    finished = True
+                elif user_input == 'p':
+                    use_previous = True
+                    uncertain_pairs.append(record_pair)
         
         if len(examples_buffer) > buffer_len:
-            (record_pair, label) = examples_buffer.pop()
+            record_pair, label = examples_buffer.pop()
             if label in ['distinct', 'match']:
                 examples = {'distinct' : [], 'match' : []}
                 examples[label].append(record_pair)
                 deduper.markPairs(examples)
-       
-    for (record_pair, label) in examples_buffer:
+
+    for record_pair, label in examples_buffer:
         if label in ['distinct', 'match']:
             examples = {'distinct' : [], 'match' : []}
             examples[label].append(record_pair)

--- a/dedupe/convenience.py
+++ b/dedupe/convenience.py
@@ -74,18 +74,18 @@ def consoleLabel(deduper): # pragma: no cover
             if user_input in valid_responses:
                 valid_response = True
 
-                if user_input == 'y' :
-                    examples_buffer.insert(0, (record_pair, 'match'))
-                elif user_input == 'n' :
-                    examples_buffer.insert(0, (record_pair, 'distinct'))
-                elif user_input == 'u':
-                    examples_buffer.insert(0, (record_pair, 'uncertain'))
-                elif user_input == 'f':
-                    print('Finished labeling', file=sys.stderr)
-                    finished = True
-                elif user_input == 'p':
-                    use_previous = True
-                    uncertain_pairs.append(record_pair)
+            if user_input == 'y' :
+                examples_buffer.insert(0, (record_pair, 'match'))
+            elif user_input == 'n' :
+                examples_buffer.insert(0, (record_pair, 'distinct'))
+            elif user_input == 'u':
+                examples_buffer.insert(0, (record_pair, 'uncertain'))
+            elif user_input == 'f':
+                print('Finished labeling', file=sys.stderr)
+                finished = True
+            elif user_input == 'p':
+                use_previous = True
+                uncertain_pairs.append(record_pair)
         
         if len(examples_buffer) > buffer_len:
             record_pair, label = examples_buffer.pop()

--- a/dedupe/convenience.py
+++ b/dedupe/convenience.py
@@ -29,7 +29,6 @@ def consoleLabel(deduper): # pragma: no cover
                     for field
                     in deduper.data_model.primary_fields)
 
-
     buffer_len = 1 # Max number of previous operations
     record_label_buffer = []
     uncertain_pairs = []
@@ -85,21 +84,26 @@ def consoleLabel(deduper): # pragma: no cover
         elif label == 'f':
             print('Finished labeling', file=sys.stderr)
             finished = True
+        elif label == 'u':
+            record_label_buffer.insert(0, (record_pair, 'uncertain'))
+            uncertain_pairs.pop() 
         elif (label == 'p') and len(record_label_buffer):
             use_previous = True
-        elif label != 'u':
+        else:
             print('Nonvalid response', file=sys.stderr)
             raise
         
         if len(record_label_buffer) > buffer_len:
             (record_pair, true_label) = record_label_buffer.pop()
-            examples = {'distinct' : [], 'match' : []}
-            examples[true_label].append(record_pair)
-            deduper.markPairs(examples)
+            if true_label in ['distinct', 'match']:
+                examples = {'distinct' : [], 'match' : []}
+                examples[true_label].append(record_pair)
+                deduper.markPairs(examples)
        
     for (record_pair, true_label) in record_label_buffer:
-        examples = {'distinct' : [], 'match' : []}
-        examples[true_label].append(record_pair)
+        if true_label in ['distinct', 'match']:
+            examples = {'distinct' : [], 'match' : []}
+            examples[true_label].append(record_pair)
     deduper.markPairs(examples)
 # 
 


### PR DESCRIPTION
When using the command line interface to label data, I sometimes made mistakes requiring me to start labeling all over again (or to manually delete text from the `training.json` file). As this could get somewhat frustrating, I added a "(p)revious" command that allows users to go back to labelling previous labels if one are several mistakes are made.

Interface looks as follows:

```
### Previous is possible
(y)es / (n)o / (u)nsure / (f)inished / (p)revious

### Previous is not possible 
(y)es / (n)o / (u)nsure / (f)inished

### Previous is not possible but p was given as input
(p)revious is not a valid answer (no record in memory)
(y)es / (n)o / (u)nsure / (f)inished
```

This solution uses a fixed length buffer to store examples. These examples are marked (using `deduper.markPairs(examples)`) only once the buffer is full, allowing the user to go back as many steps as the buffer length. By default, I set the buffer length to 1 in the code (`buffer_len = 1`, `consoleLabel`) not being sure what was the appropriate way to add parameters to this function (through deduper, or new variable). The left over data in the buffer is marked at the end of training

Also, I assumed `deduper.uncertainPairs()` would always return a single pair, so I added an assertion to check that and removed a loop on `uncertain_pairs` (instead: `record_pair = uncertain_pairs[0]`).

I hope this can be useful in any way. This is my first pull request on a public project; please let me know if I am doing something wrong :) 